### PR TITLE
Issue 35

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,4 @@ include etl_manager/specs/csv_quoted_nodate_specific.json
 include etl_manager/specs/par_specific.json
 include etl_manager/specs/csv_specific.json
 include etl_manager/specs/regex_specific.json
-include etl_manager/data/data_type_conversion.csv
+include etl_manager/specs/glue_spark_dict.json

--- a/README.md
+++ b/README.md
@@ -38,11 +38,15 @@ file.csv is a table that looks like this:
 | c    | 42   |
 
 As you can see col1 is a string and col2 is a integer.
-**Notes:**
+
+#### Notes:
+
 - for Athena to work your table should not contain a header. So before file.csv is uploaded to S3 you should make sure it has no header.
 - Tables must be in a folder. I.e. the location of your table (`table.location`) should be the parent folder of where you data exists. See example below.
 
 To create a schema for your data to be queried by Athena you can use the following code:
+
+#### Basic Example
 
 ```python
 from etl_manager.meta import DatabaseMeta, TableMeta
@@ -93,8 +97,8 @@ The employees table has an ID for each employee their name and dob. The table me
 
 ```json
 {
-    "table_name": "employees",
-    "table_desc": "table containing employee information",
+    "name": "employees",
+    "description": "table containing employee information",
     "data_format": "parquet",
     "location": "employees/",
     "columns": [
@@ -121,8 +125,8 @@ The teams table is a list of employee IDs for each team. Showing which employees
 
 ```json
 {
-    "table_name": "teams",
-    "table_desc": "month snapshot of which employee with working in what team",
+    "name": "teams",
+    "description": "month snapshot of which employee with working in what team",
     "data_format": "parquet",
     "location": "teams/",
     "columns": [
@@ -161,9 +165,9 @@ The teams table is a list of employee IDs for each team. Showing which employees
 The code snippet below creates a database meta object that allows you to manipulate the database and the tables that exist in it
 
 ```python
-from etl_manager.meta import DatabaseMeta
+from etl_manager.meta import read_database_folder
 
-db = DatabaseMeta('example_meta_data/')
+db = read_database_folder('example_meta_data/')
 
 # Database has callable objects
 
@@ -193,4 +197,3 @@ for t in db_table_names :
     db.table(t).data_format = 'parquet'
 db.create_glue_database()
 ```
-    

--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -1,4 +1,4 @@
-from etl_manager.utils import _read_json, _write_json, _dict_merge, _validate_string, _glue_client, _unnest_github_zipfile_and_return_new_zip_path, _s3_client, _s3_resource
+from etl_manager.utils import read_json, write_json, _dict_merge, _validate_string, _glue_client, _unnest_github_zipfile_and_return_new_zip_path, _s3_client, _s3_resource
 from urllib.request import urlretrieve
 import os
 import re

--- a/etl_manager/meta.py
+++ b/etl_manager/meta.py
@@ -1,4 +1,4 @@
-from etl_manager.utils import _read_json, _write_json, _dict_merge, _end_with_slash, _validate_string, _glue_client, _s3_resource, _remove_final_slash
+from etl_manager.utils import read_json, write_json, _dict_merge, _end_with_slash, _validate_string, _glue_client, _s3_resource, _remove_final_slash
 from copy import copy
 import string
 import json
@@ -206,7 +206,7 @@ class TableMeta :
         return meta
 
     def write_to_json(self, file_path) :
-        _write_json(self.to_dict(), file_path)
+        write_json(self.to_dict(), file_path)
 
     def generate_markdown_doc(self, filepath) :
         """
@@ -443,7 +443,7 @@ class DatabaseMeta :
         The table meta data json will be saved as <table_name>.json where table_name == table.name.
         """
 
-        _write_json(self.to_dict(), os.path.join(folder_path, 'database.json'))
+        write_json(self.to_dict(), os.path.join(folder_path, 'database.json'))
 
         if write_tables :
             for t in self._tables :
@@ -454,7 +454,7 @@ class DatabaseMeta :
                 table.refresh_paritions()
 
 def read_table_json(filepath, database = None) :
-    meta = _read_json(filepath)
+    meta = read_json(filepath)
     if 'partitions' not in meta :
         meta['partitions'] = []
 
@@ -473,7 +473,7 @@ def read_table_json(filepath, database = None) :
     return tab
 
 def read_database_json(filepath) :
-    db_meta = _read_json(filepath)
+    db_meta = read_json(filepath)
     db = DatabaseMeta(name=db_meta['name'], bucket=db_meta['bucket'], location=db_meta['location'], description=db_meta['description'])
     return db
 

--- a/etl_manager/meta.py
+++ b/etl_manager/meta.py
@@ -320,7 +320,7 @@ class DatabaseMeta :
     This will create a database object that also holds table objects for each table json in the folder it is pointed to.
     The meta data folder used to initialise the database must contain a database.json file.
     """
-    def __init__(self, database_folder_path, db_suffix = '_dev') :
+    def __init__(self, database_folder_path, db_suffix = '') :
 
         self._tables = []
         database_folder_path = _end_with_slash(database_folder_path)

--- a/etl_manager/specs/glue_spark_dict.json
+++ b/etl_manager/specs/glue_spark_dict.json
@@ -1,0 +1,10 @@
+{
+    "character" : {"glue" : "string", "spark": "StringType"},
+    "int" : {"glue" : "int", "spark": "IntegerType"},
+    "long" : {"glue" : "bigint", "spark": "LongType"},
+    "float" : {"glue" : "float", "spark": "FloatType"},
+    "double" : {"glue" : "double", "spark": "DoubleType"},
+    "date" : {"glue" : "date", "spark": "DateType"},
+    "datetime" : {"glue" : "timestamp", "spark": "TimestampType"},
+    "boolean" : {"glue" : "boolean", "spark": "BooleanType"}
+}

--- a/etl_manager/utils.py
+++ b/etl_manager/utils.py
@@ -37,13 +37,13 @@ def _dict_merge(dct, merge_dct):
             dct[k] = merge_dct[k]
 
 # Read json file
-def _read_json(filename) :
+def read_json(filename) :
     with open(filename) as json_data:
         data = json.load(json_data)
     return data
 
 # Write json file
-def _write_json(data, filename) :
+def write_json(data, filename) :
     with open(filename, 'w+') as outfile:
         json.dump(data, outfile, indent=4, separators=(',', ': '))
 

--- a/example/meta_data/db1/database.json
+++ b/example/meta_data/db1/database.json
@@ -2,5 +2,5 @@
     "description": "Example database",
     "name": "workforce",
     "bucket": "my-bucket",
-    "location": "database/database1"
+    "base_folder": "database/database1"
 }

--- a/example/meta_data/db1/database.json
+++ b/example/meta_data/db1/database.json
@@ -2,6 +2,5 @@
     "description": "Example database",
     "name": "workforce",
     "bucket": "my-bucket",
-    "base_folder": "my_folder",
     "location": "database/database1"
 }

--- a/example/meta_data/db1/employees.json
+++ b/example/meta_data/db1/employees.json
@@ -1,7 +1,6 @@
 {
-    "id": "workforce.employees",
-    "table_name": "employees",
-    "table_desc": "table containing employee information",
+    "name": "employees",
+    "description": "table containing employee information",
     "data_format": "parquet",
     "location": "employees/",
     "columns": [

--- a/example/meta_data/db1/pay.json
+++ b/example/meta_data/db1/pay.json
@@ -1,0 +1,30 @@
+{
+    "name": "pay",
+    "description": "Check glue specific works",
+    "data_format": "csv",
+    "location": "pay/",
+    "columns": [
+        {
+            "name": "employee_id",
+            "type": "int",
+            "description": "an ID for each employee"
+        },
+        {
+            "name": "annual_salary",
+            "type": "float",
+            "description": "Annual salary"
+        }
+    ],
+    "glue_specific": {
+        "Parameters": {
+            "skip.header.line.count": "1"
+        },
+        "StorageDescriptor": {
+            "Parameters": {
+                "skip.header.line.count": "1"
+            }
+        }
+    }
+
+
+}

--- a/example/meta_data/db1/teams.json
+++ b/example/meta_data/db1/teams.json
@@ -1,7 +1,6 @@
 {
-    "id": "workforce.teams",
-    "table_name": "teams",
-    "table_desc": "month snapshot of which employee with working in what team",
+    "name": "teams",
+    "description": "month snapshot of which employee with working in what team",
     "data_format": "parquet",
     "location": "teams/",
     "columns": [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='etl_manager',
-    version='0.1',
+    version='1.0',
     packages=find_packages(exclude=['tests*']),
     license='MIT',
     description='A python package to manage etl processes on AWS',

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -126,7 +126,7 @@ class DatabaseMetaTest(unittest.TestCase):
 
     def test_db_table_names(self) :
         db = read_database_folder('example/meta_data/db1/')
-        t = all(t in ['teams', 'employees'] for t in db.table_names)
+        t = all(t in ['teams', 'employees', 'pay'] for t in db.table_names)
         self.assertTrue(t)
 
     def test_db_glue_name(self) :
@@ -145,16 +145,24 @@ class DatabaseMetaTest(unittest.TestCase):
         self.assertTrue(isinstance(db.table('employees'), TableMeta))
         self.assertRaises(ValueError, db.table, 'not_a_table_name')
 
+    def test_glue_specific_table(self):
+        t = read_table_json("example/meta_data/db1/pay.json")
+        glue_def = t.glue_table_definition("db_path")
+        self.assertTrue(t.glue_table_definition("db_path")["Parameters"]['skip.header.line.count'] == '1')
+
+
+
+
     def test_add_remove_table(self) :
         db = read_database_folder('example/meta_data/db1/')
         self.assertRaises(ValueError, db.remove_table, 'not_a_table')
         db.remove_table('employees')
         tns = db.table_names
-        self.assertEqual(tns[0], 'teams')
+        self.assertEqual(set(tns),set(['teams', 'pay']))
 
         emp_table = read_table_json('example/meta_data/db1/employees.json')
         db.add_table(emp_table)
-        t = all(t in ['teams', 'employees'] for t in db.table_names)
+        t = all(t in ['teams', 'employees', 'pay'] for t in db.table_names)
         self.assertTrue(t)
 
         self.assertRaises(ValueError, db.add_table, 'not a table obj')
@@ -190,13 +198,13 @@ class DatabaseMetaTest(unittest.TestCase):
             print("\n***\nCANNOT RUN THIS UNIT TEST AS DO NOT HAVE ACCESS TO AWS.\n***\nskipping ...")
             self.assertTrue(True)
 
-class TableMetaTest(unittest.TestCase): 
+class TableMetaTest(unittest.TestCase):
     """
-    Test Table Meta class 
+    Test Table Meta class
     """
     def test_null_init(self) :
         tm = TableMeta('test_name')
-        
+
         self.assertEqual(tm.name, 'test_name')
         self.assertEqual(tm.description, '')
         self.assertEqual(tm.data_format, 'csv')

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -90,7 +90,7 @@ class DatabaseMetaTest(unittest.TestCase):
     """
 
     def test_init(self) :
-        db = DatabaseMeta('example/meta_data/db1/')
+        db = DatabaseMeta('example/meta_data/db1/', '_dev')
 
         self.assertEqual(db.name, 'workforce_dev')
         self.assertEqual(db.description, 'Example database')
@@ -127,7 +127,10 @@ class DatabaseMetaTest(unittest.TestCase):
 
     def test_db_glue_name(self) :
         db = DatabaseMeta('example/meta_data/db1/')
-        self.assertEqual(db.name, 'workforce_dev')
+        self.assertEqual(db.name, 'workforce')
+
+        db_dev = DatabaseMeta('example/meta_data/db1/', '_dev')
+        self.assertEqual(db_dev.name, 'workforce_dev')
 
     def test_db_s3_database_path(self) :
         db = DatabaseMeta('example/meta_data/db1/')

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -95,7 +95,6 @@ class DatabaseMetaTest(unittest.TestCase):
         self.assertEqual(db.name, 'workforce_dev')
         self.assertEqual(db.description, 'Example database')
         self.assertEqual(db.bucket, 'my-bucket')
-        self.assertEqual(db.base_folder, "my_folder")
         self.assertEqual(db.location, 'database/database1')
         self.assertEqual(db.db_suffix, '_dev')
 
@@ -111,8 +110,6 @@ class DatabaseMetaTest(unittest.TestCase):
         self.assertEqual(db.description,'new description')
         db.bucket = 'new-bucket'
         self.assertEqual(db.bucket, 'new-bucket')
-        db.base_folder = 'this/is/a/base/folder/'
-        self.assertEqual(db.base_folder, 'this/is/a/base/folder')
         db.location = 'new/folder/location'
         self.assertEqual(db.location, 'new/folder/location')
         db.db_suffix = 'new_suffix'
@@ -134,7 +131,7 @@ class DatabaseMetaTest(unittest.TestCase):
 
     def test_db_s3_database_path(self) :
         db = DatabaseMeta('example/meta_data/db1/')
-        self.assertEqual(db.s3_database_path, 's3://my-bucket/my_folder_dev/database/database1')
+        self.assertEqual(db.s3_database_path, 's3://my-bucket/database/database1')
 
     def test_db_table(self) :
         db = DatabaseMeta('example/meta_data/db1/')
@@ -161,7 +158,7 @@ class DatabaseMetaTest(unittest.TestCase):
         tbl = db.table('teams')
         gtd = tbl.glue_table_definition()
         location = gtd["StorageDescriptor"]["Location"]
-        self.assertTrue(location == 's3://my-bucket/my_folder_dev/database/database1/teams/')
+        self.assertTrue(location == 's3://my-bucket/database/database1/teams/')
 
     def test_glue_database_creation(self) :
         session = boto3.Session()

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -90,21 +90,21 @@ class DatabaseMetaTest(unittest.TestCase):
     """
 
     def test_init(self) :
-        db = DatabaseMeta(name = 'workforce', bucket = 'my-bucket', location = 'database/database1', description='Example database')
+        db = DatabaseMeta(name = 'workforce', bucket = 'my-bucket', base_folder = 'database/database1', description='Example database')
         self.assertEqual(db.name, 'workforce')
         self.assertEqual(db.description, 'Example database')
         self.assertEqual(db.bucket, 'my-bucket')
-        self.assertEqual(db.location, 'database/database1')
+        self.assertEqual(db.base_folder, 'database/database1')
 
     def testread_json(self) :
         db = read_database_folder('example/meta_data/db1/')
         self.assertEqual(db.name, 'workforce')
         self.assertEqual(db.description, 'Example database')
         self.assertEqual(db.bucket, 'my-bucket')
-        self.assertEqual(db.location, 'database/database1')
+        self.assertEqual(db.base_folder, 'database/database1')
 
     def test_db_to_dict(self) :
-        db = DatabaseMeta(name = 'workforce', bucket = 'my-bucket', location = 'database/database1', description='Example database')
+        db = DatabaseMeta(name = 'workforce', bucket = 'my-bucket', base_folder = 'database/database1', description='Example database')
         db_dict = read_json('example/meta_data/db1/database.json')
         self.assertDictEqual(db_dict, db.to_dict())
 
@@ -116,8 +116,8 @@ class DatabaseMetaTest(unittest.TestCase):
         self.assertEqual(db.description,'new description')
         db.bucket = 'new-bucket'
         self.assertEqual(db.bucket, 'new-bucket')
-        db.location = 'new/folder/location'
-        self.assertEqual(db.location, 'new/folder/location')
+        db.base_folder = 'new/folder/location'
+        self.assertEqual(db.base_folder, 'new/folder/location')
 
     def test_table_to_dict(self) :
         db = read_database_folder('example/meta_data/db1/')
@@ -203,12 +203,12 @@ class TableMetaTest(unittest.TestCase):
     Test Table Meta class
     """
     def test_null_init(self) :
-        tm = TableMeta('test_name')
+        tm = TableMeta('test_name', location = 'folder/')
 
         self.assertEqual(tm.name, 'test_name')
         self.assertEqual(tm.description, '')
         self.assertEqual(tm.data_format, 'csv')
-        self.assertEqual(tm.location, '')
+        self.assertEqual(tm.location, 'folder/')
         self.assertEqual(tm.columns, [])
         self.assertEqual(tm.partitions, [])
         self.assertEqual(tm.glue_specific, {})

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -6,7 +6,7 @@ Testing DatabaseMeta, TableMeta
 
 import unittest
 from etl_manager.meta import DatabaseMeta, TableMeta, read_database_folder, read_table_json
-from etl_manager.utils import _end_with_slash, _validate_string, _glue_client, _read_json, _remove_final_slash
+from etl_manager.utils import _end_with_slash, _validate_string, _glue_client, read_json, _remove_final_slash
 from etl_manager.etl import GlueJob
 import boto3
 
@@ -96,7 +96,7 @@ class DatabaseMetaTest(unittest.TestCase):
         self.assertEqual(db.bucket, 'my-bucket')
         self.assertEqual(db.location, 'database/database1')
 
-    def test_read_json(self) :
+    def testread_json(self) :
         db = read_database_folder('example/meta_data/db1/')
         self.assertEqual(db.name, 'workforce')
         self.assertEqual(db.description, 'Example database')
@@ -105,7 +105,7 @@ class DatabaseMetaTest(unittest.TestCase):
 
     def test_db_to_dict(self) :
         db = DatabaseMeta(name = 'workforce', bucket = 'my-bucket', location = 'database/database1', description='Example database')
-        db_dict = _read_json('example/meta_data/db1/database.json')
+        db_dict = read_json('example/meta_data/db1/database.json')
         self.assertDictEqual(db_dict, db.to_dict())
 
     def test_db_value_properties(self) :
@@ -121,7 +121,7 @@ class DatabaseMetaTest(unittest.TestCase):
 
     def test_table_to_dict(self) :
         db = read_database_folder('example/meta_data/db1/')
-        test_dict = _read_json('example/meta_data/db1/teams.json')
+        test_dict = read_json('example/meta_data/db1/teams.json')
         self.assertDictEqual(test_dict, db.table('teams').to_dict())
 
     def test_db_table_names(self) :


### PR DESCRIPTION
This PR Closes issue #35, #36 and #37 Further changes to note:

**Further changes to note**
- db_suffix has been dropped completely. To set a suffix do it manually e.g. `db.name = db.name + db_suffix`

- `db = DatabaseMeta(folderpath)` is now replaced with `db = read_database_folder(folderpath)`. `table = TableMeta(filepath)` is now replaced with table = read_table_json(filepath)`. 

- `DatabaseMeta()` and `TableMeta()` constructors are now more standard with input parameters to define an object. e.g. `table = TableMeta(name = 'table_name')`

- keys in a table json definition have been updated to align with database keys. Specifically `table_name` has been replaced with `name` and `table_desc` has been changed with `description`.
