### PR TITLE
Added another check to the glue job parameters

### DIFF
--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -132,6 +132,8 @@ class GlueJob:
             for k in job_arguments.keys() :
                 if k[:2] != '--' or k in special_aws_params:
                     raise ValueError("Found incorrect AWS job argument ({}). All arguments should begin with '--' and cannot be one of the following: {}".format(k, ', '.join(special_aws_params)))
+                if '-' in k[2:] :
+                    raise ValueError("Avoid using '-' in job parameter names (use '_' instead). AWS Glue will convert any dash in a glue job parameter name to an underscore - so we stop our users from doing this.")
         self._job_arguments = job_arguments
 
     @property

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -51,6 +51,17 @@ class GlueTest(unittest.TestCase) :
 
         self.assertTrue("_GlueJobs_" in g2.job_arguments['--metadata_base_path'])
 
+    def test_glue_param_error(self) :
+        g = GlueJob('example/glue_jobs/simple_etl_job/', bucket = 'alpha-everyone', job_role = 'alpha_user_isichei', job_arguments={'--test_arg': 'this is a test'})
+        with self.assertRaises(ValueError):
+            g.job_arguments = '--bad_job_argument1'
+        with self.assertRaises(ValueError):
+            g.job_arguments = {'bad_job_argument2' : 'test'}
+        with self.assertRaises(ValueError):
+            g.job_arguments = {'--bad-job-argument3' : 'test'}
+        with self.assertRaises(ValueError):
+            g.job_arguments = {"--JOB_NAME" : "new_job_name"}
+
     def test_db_value_properties(self) :
         g = GlueJob('example/glue_jobs/simple_etl_job/', bucket = 'alpha-everyone', job_role = 'alpha_user_isichei', job_arguments={'--test_arg': 'this is a test'})
 
@@ -61,19 +72,12 @@ class GlueTest(unittest.TestCase) :
         self.assertEqual(g.bucket, "new-bucket")
         with self.assertRaises(ValueError):
             g.bucket = "s3://new-bucket"
-            g.bucket = "new_bucket"
 
         g.job_role = 'alpha_new_user'
         self.assertEqual(g.job_role, 'alpha_new_user')
 
         g.job_arguments = {"--new_args" : "something"}
         self.assertEqual(g.job_arguments["--new_args"], "something")
-
-        with self.assertRaises(ValueError) :
-            g.job_arguments = "not a dict"
-            g.job_arguments = {"--JOB_NAME" : "new_job_name"}
-            g.job_arguments = {"no_dash" : "test"}
-
 
 class TableTest(unittest.TestCase):
 


### PR DESCRIPTION
Glue Job Class will throw an error if the parameters have a dash in the name. Also added a unit test for Glue job parameters and removed duplicate tests on job params.