### PR TITLE
Added GlueJob.wait_for_completion()

### DIFF
--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -1,13 +1,23 @@
-from etl_manager.utils import read_json, write_json, _dict_merge, _validate_string, _glue_client, _unnest_github_zipfile_and_return_new_zip_path, _s3_client, _s3_resource
 from urllib.request import urlretrieve
+import glob
+import json
 import os
 import re
-import json
-import tempfile
-import zipfile
 import shutil
-import glob
+import tempfile
 import time
+import zipfile
+
+from etl_manager.utils import (
+    read_json,
+    write_json,
+    _dict_merge,
+    _validate_string,
+    _glue_client,
+    _unnest_github_zipfile_and_return_new_zip_path,
+    _s3_client,
+    _s3_resource,
+)
 
 
 # Create temp folder - upload to s3

--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -404,7 +404,7 @@ class GlueJob:
 
         return status['JobRun']['JobRunState'].lower()
 
-    def wait_completion(self):
+    def wait_for_completion(self):
         """
         Wait for the job to complete.
 

--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -385,12 +385,28 @@ class GlueJob:
 
         return status['JobRun']['JobRunState'].lower()
 
+    def cleanup(self):
+        """
+        Delete the Glue Job resources (the job itself and the S3 objects)
+        """
+
+        self.delete_job()
+        self.delete_s3_job_temp_folder()
+
     def delete_job(self) :
+        """
+        DEPRECATED: Use `cleanup()`
+        """
+
         if self.job_name is None:
             raise JobMisconfigured('Missing "job_name"')
 
         _glue_client.delete_job(JobName=self.job_name)
 
     def delete_s3_job_temp_folder(self) :
+        """
+        DEPRECATED: Use `cleanup()`
+        """
+
         bucket = _s3_resource.Bucket(self.bucket)
         bucket.objects.filter(Prefix=self.s3_job_folder_no_bucket).delete()


### PR DESCRIPTION
`GlueJob.wait_for_completion()` allows the client code to poll for the Glue Job status until the job
"completed" or failed.

By completed here we mean the job run was successful or it was manually stopped.

In addition to this, if a job failed or timed out the method will raise an exception (`JobFailed` and `JobTimedOut` respectively)

Also:
- Added `GlueJob.cleanup()` and deprecated low level methods `GlueJob.delete_job()` and `GlueJob. delete_s3_job_temp_folder()`
- fixed import order as per [PEP8](
https://www.python.org/dev/peps/pep-0008/#imports)