### PR TITLE
Handle missing status's ["JobRun"]["ErrorMessage"]

### DIFF
--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -420,7 +420,11 @@ class GlueJob:
 
             status = self.job_status
             status_code = status["JobRun"]["JobRunState"]
-            status_error = status["JobRun"]["ErrorMessage"]
+            status_error = "Unknown"
+            try:
+                status_error = status["JobRun"]["ErrorMessage"]
+            except KeyError:
+                pass
 
             if status_code in ("SUCCEEDED", "STOPPED"):
                 break

--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -420,11 +420,7 @@ class GlueJob:
 
             status = self.job_status
             status_code = status["JobRun"]["JobRunState"]
-            status_error = "Unknown"
-            try:
-                status_error = status["JobRun"]["ErrorMessage"]
-            except KeyError:
-                pass
+            status_error = status["JobRun"].get("ErrorMessage", default="Unknown")
 
             if status_code in ("SUCCEEDED", "STOPPED"):
                 break


### PR DESCRIPTION
Unfortunately this key is not always there.
I was expecting this key to be there as blank string when
there were no errors but that's not the case.

This breaks `wait_for_completion()` :(

This should fix it.