### PR TITLE
Take 2: Fix for `KeyError` when no `ErrorMessage`

### DIFF
--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -420,7 +420,7 @@ class GlueJob:
 
             status = self.job_status
             status_code = status["JobRun"]["JobRunState"]
-            status_error = status["JobRun"].get("ErrorMessage", default="Unknown")
+            status_error = status["JobRun"].get("ErrorMessage", "Unknown")
 
             if status_code in ("SUCCEEDED", "STOPPED"):
                 break


### PR DESCRIPTION
It seems like passing the `default` to get() doesn't work.