### PR TITLE
Various refactorings/cleanups:

### DIFF
--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -67,16 +67,15 @@ class GlueJob:
       job_folder
         etc...
     """
-    def __init__(self, job_folder, bucket, job_role, job_name = None, job_arguments = {}, include_shared_job_resources = True) :
+
+    def __init__(self, job_folder, bucket, job_role, job_name = None, job_arguments = {}, include_shared_job_resources = True):
         self.job_id = "{:0.0f}".format(time.time())
 
         job_folder = os.path.normpath(job_folder)
         self._job_folder = job_folder
 
         if not os.path.exists(self.job_path) :
-            raise ValueError("Could not find job.py in base directory provided ({}), stopping.\nOnly folder allowed to have no job.py is a folder named shared_job_resources".format(job_folder))
-
-        glue_job_folder_split = self.job_folder.split('/')
+            raise ValueError(f"Could not find job.py in base directory provided ({job_folder}), stopping.\nOnly folder allowed to have no job.py is a folder named shared_job_resources")
 
         self.bucket = bucket
         if job_name is None :
@@ -101,10 +100,8 @@ class GlueJob:
         self.max_concurrent_runs = 1
         self.allocated_capacity = 2
 
-
-
     @property
-    def job_folder(self) :
+    def job_folder(self):
         return self._job_folder
 
     @property
@@ -112,23 +109,23 @@ class GlueJob:
         return os.path.join(self.job_folder, "job.py")
 
     @property
-    def s3_job_folder_inc_bucket(self) :
-        return "s3://{}/{}".format(self.bucket, self.s3_job_folder_no_bucket)
+    def s3_job_folder_inc_bucket(self):
+        return f"s3://{self.bucket}/{self.s3_job_folder_no_bucket}"
 
     @property
-    def s3_job_folder_no_bucket(self) :
+    def s3_job_folder_no_bucket(self):
         return os.path.join('_GlueJobs_', self.job_name, self.job_id, 'resources/')
 
     @property
-    def s3_metadata_base_folder_inc_bucket(self) :
+    def s3_metadata_base_folder_inc_bucket(self):
         return os.path.join(self.s3_job_folder_inc_bucket, "meta_data")
 
     @property
-    def s3_metadata_base_folder_no_bucket(self) :
+    def s3_metadata_base_folder_no_bucket(self):
         return os.path.join(self.s3_job_folder_no_bucket, "meta_data")
 
     @property
-    def job_parent_folder(self) :
+    def job_parent_folder(self):
         return os.path.dirname(self.job_folder)
 
     @property
@@ -137,63 +134,65 @@ class GlueJob:
 
     @property
     def job_arguments(self):
-        metadata_argument = {"--metadata_base_path": self.s3_metadata_base_folder_inc_bucket}
+        metadata_argument = {
+            "--metadata_base_path": self.s3_metadata_base_folder_inc_bucket,
+        }
         return {**self._job_arguments, **metadata_argument}
 
     @job_arguments.setter
-    def job_arguments(self, job_arguments) :
+    def job_arguments(self, job_arguments):
         # https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html
-        if job_arguments is not None :
-            if not isinstance(job_arguments, dict) :
+        if job_arguments is not None:
+            if not isinstance(job_arguments, dict):
                 raise ValueError("job_arguments must be a dictionary")
             # validate dict keys
             special_aws_params = ['--JOB_NAME', '--conf', '--debug', '--mode', '--metadata_base_path']
-            for k in job_arguments.keys() :
+            for k in job_arguments.keys():
                 if k[:2] != '--' or k in special_aws_params:
                     raise ValueError("Found incorrect AWS job argument ({}). All arguments should begin with '--' and cannot be one of the following: {}".format(k, ', '.join(special_aws_params)))
-                if '-' in k[2:] :
+                if '-' in k[2:]:
                     raise ValueError("Avoid using '-' in job parameter names (use '_' instead). AWS Glue will convert any dash in a glue job parameter name to an underscore - so we stop our users from doing this.")
         self._job_arguments = job_arguments
 
     @property
-    def bucket(self) :
+    def bucket(self):
         return self._bucket
 
     @bucket.setter
-    def bucket(self, bucket) :
+    def bucket(self, bucket):
         _validate_string(bucket, '-,')
         self._bucket = bucket
 
     @property
-    def job_name(self) :
+    def job_name(self):
         return self._job_name
 
     @job_name.setter
-    def job_name(self, job_name) :
+    def job_name(self, job_name):
         _validate_string(job_name, allowed_chars="-_:")
         self._job_name = job_name
 
     @property
-    def job_run_id(self) :
+    def job_run_id(self):
         return self._job_run_id
 
-    def _check_nondup_resources(self, resources_list) :
+    def _check_nondup_resources(self, resources_list):
         file_list = [os.path.basename(r) for r in resources_list]
-        if(len(file_list) != len(set(file_list))) :
+        if(len(file_list) != len(set(file_list))):
             raise ValueError("There are duplicate file names in your supplied resources. A file in job resources might share the same name as a file in the shared resources folders.")
 
-    def _get_github_resource_list(self) :
+    def _get_github_resource_list(self):
         zip_urls_path = os.path.join(self.job_folder, "glue_py_resources", "github_zip_urls.txt")
         shared_zip_urls_path = os.path.join(self.job_parent_folder, "shared_job_resources", "glue_py_resources", "github_zip_urls.txt")
 
-        if os.path.exists(zip_urls_path) :
+        if os.path.exists(zip_urls_path):
             with open(zip_urls_path, "r") as f:
                 urls = f.readlines()
             f.close()
-        else :
+        else:
             urls = []
 
-        if os.path.exists(shared_zip_urls_path) and self.include_shared_job_resources :
+        if os.path.exists(shared_zip_urls_path) and self.include_shared_job_resources:
             with open(shared_zip_urls_path, "r") as f:
                 shared_urls = f.readlines()
             f.close()
@@ -212,7 +211,6 @@ class GlueJob:
         else:
             return []
 
-
     def _get_py_resources(self):
         # Upload all the .py or .zip files in resources
         # Check existence of folder, otherwise skip
@@ -225,14 +223,13 @@ class GlueJob:
 
         resource_listing = self._list_folder_with_regex(resources_path, regex)
 
-        if self.include_shared_job_resources :
+        if self.include_shared_job_resources:
             shared_resource_listing = self._list_folder_with_regex(shared_resources_path, regex)
             resource_listing = resource_listing + shared_resource_listing
 
         return resource_listing
 
-
-    def _get_resources(self) :
+    def _get_resources(self):
         # Upload all the .py or .zip files in resources
         # Check existence of folder, otherwise skip
 
@@ -244,7 +241,7 @@ class GlueJob:
 
         resource_listing = self._list_folder_with_regex(resources_path, regex)
 
-        if self.include_shared_job_resources :
+        if self.include_shared_job_resources:
             shared_resource_listing = self._list_folder_with_regex(shared_resources_path, regex)
             resource_listing = resource_listing + shared_resource_listing
 
@@ -254,15 +251,15 @@ class GlueJob:
         """
         Enumerate the relative path for all metadata json files
         """
+
         metadata_base = os.path.join(self.etl_root_folder, "meta_data")
         all_files = list(glob.iglob(metadata_base + "/**/*.json", recursive=True))
 
         # Remove everything up to the main meta_data path
         return list(all_files)
 
-    def _download_github_zipfile_and_rezip_to_glue_file_structure(self, url) :
-
-        this_zip_path = os.path.join('_' + self.job_name + '_tmp_zip_files_to_s3_',"github.zip")
+    def _download_github_zipfile_and_rezip_to_glue_file_structure(self, url):
+        this_zip_path = os.path.join(f'_{self.job_name}_tmp_zip_files_to_s3_', "github.zip")
         urlretrieve(url, this_zip_path)
 
         original_dir = os.path.dirname(this_zip_path)
@@ -280,19 +277,18 @@ class GlueJob:
 
         return final_output_path
 
-    def sync_job_to_s3_folder(self) :
-
+    def sync_job_to_s3_folder(self):
         # Test if folder exists and create if not
         temp_folder_already_exists = False
-        temp_zip_folder = '_' + self.job_name + '_tmp_zip_files_to_s3_'
-        if os.path.exists(temp_zip_folder) :
+        temp_zip_folder = f'_{self.job_name}_tmp_zip_files_to_s3_'
+        if os.path.exists(temp_zip_folder):
             temp_folder_already_exists = True
-        else :
+        else:
             os.makedirs(temp_zip_folder)
 
         # Download the github urls and rezip them to work with aws glue
         self.github_py_resources = []
-        for url in self.github_zip_urls :
+        for url in self.github_zip_urls:
             self.github_py_resources.append(self._download_github_zipfile_and_rezip_to_glue_file_structure(url))
 
         # Check if all filenames are unique
@@ -303,78 +299,69 @@ class GlueJob:
         self.delete_s3_job_temp_folder()
 
         # Sync all job resources to the same s3 folder
-        for f in files_to_sync :
+        for f in files_to_sync:
             s3_file_path = os.path.join(self.s3_job_folder_no_bucket, os.path.basename(f))
             _s3_client.upload_file(f, self.bucket, s3_file_path)
 
         # Upload metadata to subfolder
-
         for f in self.all_meta_data_paths:
             path_within_metadata_folder = re.sub("^.*/?meta_data/", "", f)
             s3_file_path = os.path.join(self.s3_metadata_base_folder_no_bucket, path_within_metadata_folder)
             _s3_client.upload_file(f, self.bucket, s3_file_path)
 
-
         # Clean up downloaded zip files
-        for f in list(self.github_py_resources) :
+        for f in list(self.github_py_resources):
             os.remove(f)
-        if not temp_folder_already_exists :
+        if not temp_folder_already_exists:
             os.rmdir(temp_zip_folder)
 
 
-    def _create_glue_job_definition(self):
+    def _job_definition(self):
+        script_location = os.path.join(self.s3_job_folder_inc_bucket, 'job.py')
+        tmp_dir = os.path.join(self.s3_job_folder_inc_bucket, 'glue_temp_folder/')
 
-        template = {
-            "Name": "",
-            "Role": "",
+        job_definition = {
+            "Name": self.job_name,
+            "Role": self.job_role,
             "ExecutionProperty": {
-                "MaxConcurrentRuns": 1
+                "MaxConcurrentRuns": self.max_concurrent_runs,
             },
             "Command": {
                 "Name": "glueetl",
-                "ScriptLocation": ""
+                "ScriptLocation": script_location,
             },
             "DefaultArguments": {
-                "--TempDir": "",
+                "--TempDir": tmp_dir,
                 "--extra-files": "",
                 "--extra-py-files": "",
-                "--job-bookmark-option": "job-bookmark-disable"
+                "--job-bookmark-option": "job-bookmark-disable",
             },
-            "MaxRetries": None,
-            "AllocatedCapacity": None
+            "MaxRetries": self.max_retries,
+            "AllocatedCapacity": self.allocated_capacity,
         }
 
-        template["Name"] = self.job_name
-        template["Role"] = self.job_role
-        template["Command"]["ScriptLocation"] = os.path.join(self.s3_job_folder_inc_bucket, 'job.py')
-        template["DefaultArguments"]["--TempDir"] = os.path.join(self.s3_job_folder_inc_bucket, 'glue_temp_folder/')
-
-        if len(self.resources) > 0 :
+        if len(self.resources) > 0:
             extra_files = ','.join([os.path.join(self.s3_job_folder_inc_bucket, os.path.basename(f)) for f in self.resources])
-            template["DefaultArguments"]["--extra-files"] = extra_files
-        else :
-            template["DefaultArguments"].pop("--extra-files", None)
+            job_definition["DefaultArguments"]["--extra-files"] = extra_files
+        else:
+            job_definition["DefaultArguments"].pop("--extra-files", None)
 
         if len(self.py_resources) > 0 or  len(self.github_py_resources) > 0:
             extra_py_files = ','.join([os.path.join(self.s3_job_folder_inc_bucket, os.path.basename(f)) for f in (self.py_resources + self.github_py_resources)])
-            template["DefaultArguments"]["--extra-py-files"] = extra_py_files
-        else :
-            template["DefaultArguments"].pop("--extra-py-files", None)
+            job_definition["DefaultArguments"]["--extra-py-files"] = extra_py_files
+        else:
+            job_definition["DefaultArguments"].pop("--extra-py-files", None)
 
-        template["MaxRetries"] = self.max_retries
-        template["ExecutionProperty"]["MaxConcurrentRuns"] = self.max_concurrent_runs
-        template["AllocatedCapacity"] = self.allocated_capacity
+        return job_definition
 
-        return template
+    def run_job(self, sync_to_s3_before_run = True):
+        self.delete_job()
 
-    def run_job(self, sync_to_s3_before_run = True) :
-        if sync_to_s3_before_run :
+        if sync_to_s3_before_run:
             self.sync_job_to_s3_folder()
 
-        job_spec = self._create_glue_job_definition()
-
-        self.delete_job()
-        create_job_response = _glue_client.create_job(**job_spec)
+        job_definition = self._job_definition()
+        _glue_client.create_job(**job_definition)
 
         response = _glue_client.start_job_run(JobName = self.job_name, Arguments = self.job_arguments)
 
@@ -391,16 +378,13 @@ class GlueJob:
         return _glue_client.get_job_run(JobName=self.job_name, RunId=self.job_run_id)
 
     @property
-    def is_running(self) :
-        is_running = False
-        status = self.job_status
-
-        return status['JobRun']['JobRunState'] == 'RUNNING'
-
-    @property
-    def job_run_state(self) :
+    def job_run_state(self):
         status = self.job_status
         return status['JobRun']['JobRunState']
+
+    @property
+    def is_running(self):
+        return self.job_run_state == 'RUNNING'
 
     def wait_for_completion(self):
         """
@@ -436,7 +420,7 @@ class GlueJob:
         self.delete_job()
         self.delete_s3_job_temp_folder()
 
-    def delete_job(self) :
+    def delete_job(self):
         """
         DEPRECATED: Use `cleanup()`
         """
@@ -446,7 +430,7 @@ class GlueJob:
 
         _glue_client.delete_job(JobName=self.job_name)
 
-    def delete_s3_job_temp_folder(self) :
+    def delete_s3_job_temp_folder(self):
         """
         DEPRECATED: Use `cleanup()`
         """


### PR DESCRIPTION
- Renamed `_create_glue_job_definition()` => `_job_definition()` (glue is
  redundant)
- Inside `_job_definition()` avoid unnecesary variables when building the
  dictionary unless they improve readability
- `is_running` uses `job_run_state` instead of . Also removed unused
  `is_running` variable in it.
- Removed unused variables (e.g. `glue_job_folder_split` in `__init__()`)

Style changes:
- Use f-string for concatenation instead of `+` when code is still
      readable
- Removed newlines between method name and method body
- Removed spaces before colons (`:`)

**NOTE**: I'm wondering if we need to treat "RUNNING" as a special state and
have the `is_running()` property instead of the client code using something
like `job.job_run_state == 'RUNNING'` which is still clear.