### PR TITLE
Allow `--enable-metrics` job param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## v1.0.4 - 2018-09-17
+### Change
+- removed check that throws error for `-` in job parameter name due to the new Glue parameter `enable-metrics`
+
+## v1.0.3 - 2018-09-20
+### Change
+- `--conf` allowed as job param to enable spark configuration for AWS Glue
+
 ## v1.0.2 - 2018-08-30
 ### Change
 - Database meta class will now throw error if database already exists when calling create_glue_database

--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -152,8 +152,6 @@ class GlueJob:
             for k in job_arguments.keys():
                 if k[:2] != '--' or k in special_aws_params:
                     raise ValueError("Found incorrect AWS job argument ({}). All arguments should begin with '--' and cannot be one of the following: {}".format(k, ', '.join(special_aws_params)))
-                if '-' in k[2:]:
-                    raise ValueError("Avoid using '-' in job parameter names (use '_' instead). AWS Glue will convert any dash in a glue job parameter name to an underscore - so we stop our users from doing this.")
         self._job_arguments = job_arguments
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='etl_manager',
-    version='1.0.2',
+    version='1.0.4',
     packages=find_packages(exclude=['tests*']),
     license='MIT',
     description='A python package to manage etl processes on AWS',

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -58,8 +58,6 @@ class GlueTest(unittest.TestCase) :
         with self.assertRaises(ValueError):
             g.job_arguments = {'bad_job_argument2' : 'test'}
         with self.assertRaises(ValueError):
-            g.job_arguments = {'--bad-job-argument3' : 'test'}
-        with self.assertRaises(ValueError):
             g.job_arguments = {"--JOB_NAME" : "new_job_name"}
 
     def test_db_value_properties(self) :


### PR DESCRIPTION
GlueJob would throw error because `enable-metrics` had a dash in the name. Check removed.