### PR TITLE
Replacing backend Athena calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## v1.0.5 - 2018-10-10
+### Change
+- Changed back end execution of `MSK REPAIR TABLE` call to athena. Have moved from `pyathenajdbc` to `boto3` to reduce number of package dependencies. etl_manager no longer requires `pyathenajdbc` (which also means do not need Java installed).
 
 ## v1.0.4 - 2018-09-17
 ### Change

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A python package that manages our data engineering framework and implements them
 The main functionality of this package is to interact with AWS Glue to create meta data catalogues and run Glue jobs.
 
 To install:
+
 ```bash
 pip install git+git://github.com/moj-analytical-services/etl_manager.git#egg=etl_manager
 ```
@@ -26,7 +27,6 @@ Unit tests can be ran by:
 ```python
 python -m unittest tests.test_tests -v
 ```
-
 
 ## Examples
 

--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -1,4 +1,5 @@
 from urllib.request import urlretrieve
+import datetime
 import glob
 import json
 import os
@@ -386,7 +387,7 @@ class GlueJob:
     def is_running(self):
         return self.job_run_state == 'RUNNING'
 
-    def wait_for_completion(self):
+    def wait_for_completion(self, verbose=False):
         """
         Wait for the job to complete.
 
@@ -404,7 +405,11 @@ class GlueJob:
             status_code = status["JobRun"]["JobRunState"]
             status_error = status["JobRun"].get("ErrorMessage", "Unknown")
 
-            if status_code == "SUCCEEDED" :
+            if verbose:
+                timestamp = datetime.datetime.now().strftime("%Y-%B-%d %H:%M:%S")
+                print("{}: Code: {} | Error: {}".format(timestamp, status_code, status_error))
+
+            if status_code == "SUCCEEDED":
                 break
 
             if status_code == "FAILED":

--- a/etl_manager/meta.py
+++ b/etl_manager/meta.py
@@ -4,6 +4,9 @@ from etl_manager.utils import (
     _dict_merge,
     _end_with_slash,
     _validate_string,
+    _validate_enum,
+    _validate_pattern,
+    _validate_nullable,
     _athena_client,
     _glue_client,
     _s3_resource,
@@ -34,6 +37,7 @@ _web_link_to_table_json_schema = "https://raw.githubusercontent.com/moj-analytic
 
 _supported_column_types = _table_json_schema['properties']['columns']['items']['properties']["type"]["enum"]
 _supported_data_formats = _table_json_schema['properties']['data_format']["enum"]
+_column_properties = list(_table_json_schema['properties']['columns']['items']['properties'].keys())
 
 def _get_spec(spec_name) :
     if spec_name not in _template :
@@ -132,12 +136,22 @@ class TableMeta :
         self.columns = new_cols
         self.partitions = new_partitions
 
-    def add_column(self, name, type, description) :
+    def add_column(self, name, type, description, pattern = None, enum = None, nullable = None) :
         self._check_column_does_not_exists(name)
         self._check_valid_datatype(type)
         _validate_string(name)
         cols = self.columns
         cols.append({"name": name, "type": type, "description": description})
+        if enum :
+            _validate_enum(enum)
+            cols[-1]['enum'] = enum
+        if pattern :
+            _validate_pattern(pattern)
+            cols[-1]['pattern'] = pattern
+        if nullable :
+            _validate_nullable(nullable)
+            cols[-1]['nullable'] = nullable
+
         self.columns = cols
 
     def reorder_columns(self, column_name_order) :
@@ -175,28 +189,41 @@ class TableMeta :
         if column_name in self.column_names :
             raise ValueError("The column name provided ({}) already exists table in meta.".format(column_name))
 
-    def update_column(self, column_name, new_name = None, new_type = None, new_description = None) :
+    def update_column(self, column_name, **kwargs) :
 
+        if len([k for k in kwargs.keys() if k in _column_properties]) == 0 :
+            raise ValueError(f"one or more of the function inputs ({', '.join(_column_properties)}) must be specified.")
+        
         self._check_column_exists(column_name)
 
-        if new_name is None and new_type is None and new_description is None :
-            raise ValueError("one or more of the function inputs (new_name, new_type and new_description) must be specified.")
         new_cols = []
         for c in self.columns :
             if c['name'] == column_name :
 
-                if new_name is not None :
-                    _validate_string(new_name, "_")
-                    c['name'] = new_name
+                if 'name' in kwargs :
+                    _validate_string(kwargs['name'], "_")
+                    c['name'] = kwargs['name']
 
-                if new_type is not None :
-                    self._check_valid_datatype(new_type)
-                    c['type'] = new_type
+                if 'type' in kwargs :
+                    self._check_valid_datatype(kwargs['type'])
+                    c['type'] = kwargs['type']
 
-                if new_description is not None :
-                    _validate_string(new_description, "_,.")
-                    c['description'] = new_description
+                if 'description' in kwargs :
+                    _validate_string(kwargs['description'], "_,.")
+                    c['description'] = kwargs['description']
 
+                if 'pattern' in kwargs :
+                    _validate_pattern(kwargs['pattern'])
+                    c['pattern'] = kwargs['pattern']
+
+                if 'enum' in kwargs :
+                    _validate_enum(kwargs['enum'])
+                    c['enum'] = kwargs['enum']
+
+                if 'nullable' in kwargs :
+                    _validate_nullable(kwargs['nullable'])
+                    c['nullable'] = kwargs['nullable']
+                
             new_cols.append(c)
 
         self.columns = new_cols

--- a/etl_manager/specs/table_schema.json
+++ b/etl_manager/specs/table_schema.json
@@ -25,6 +25,23 @@
               "type": "string",
               "title": "The data type.  We use a limited set of data types for cross compatibility between Spark, R, Pandas etc.  See lookup here: https://github.com/moj-analytical-services/dataengineeringutils/blob/master/dataengineeringutils/data/data_type_conversion.csv",
               "enum": ["character","int","long","float","double","date","datetime","boolean"]
+            },
+            "pattern": {
+              "type": "string",
+              "title": "regex pattern that can be used to validate data in this column"
+            },
+            "enum": {
+              "type": "array",
+              "title": "An array of valid values that can exist in this column. Note NULL/None is not required, please use nullable property to define if column is nullable.",
+              "examples": [
+                ["Y", "N"],
+                [0,1,2,3,4],
+                ["England", "Northern Ireland", "Scottland", "Wales"]
+              ]
+            },
+            "nullable" : {
+              "type" : "boolean",
+              "title" : "Specifies if column is nullable (can have missing values) or not (cannot have missing values)"
             }
           }
         }

--- a/etl_manager/utils.py
+++ b/etl_manager/utils.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 
 _glue_client = boto3.client('glue', 'eu-west-1')
+_athena_client = boto3.client('athena', 'eu-west-1')
 _s3_client = boto3.client('s3')
 _s3_resource = boto3.resource('s3')
 

--- a/etl_manager/utils.py
+++ b/etl_manager/utils.py
@@ -73,6 +73,18 @@ def _validate_string(s, allowed_chars = "_") :
     if any(char in invalid_chars for char in s) :
         raise ValueError("punctuation excluding ({}) is not allowed in string".format(allowed_chars))
 
+def _validate_enum(enum) :
+    if type(enum) != list :
+        raise TypeError(f'enum must be a list. Not of type {type(enum)}')
+
+def _validate_pattern(pattern) :
+    if type(pattern) != str :
+        raise TypeError(f'pattern must be a string. Not of type {type(pattern)}')
+
+def _validate_nullable(nullable) :
+    if type(nullable) != bool :
+        raise TypeError(f'nullable must be a boolean. Not of type {type(nullable)}')
+        
 def _get_file_from_file_path(file_path) :
     return file_path.split('/')[-1]
 

--- a/example/meta_data/db1/teams.json
+++ b/example/meta_data/db1/teams.json
@@ -8,7 +8,8 @@
         {
             "name": "team_id",
             "type": "int",
-            "description": "ID given to each team"
+            "description": "ID given to each team",
+            "nullable" : false
         },
         {
             "name": "team_name",
@@ -18,7 +19,8 @@
         {
             "name": "employee_id",
             "type": "int",
-            "description": "primary key for each employee in the employees table"
+            "description": "primary key for each employee in the employees table",
+            "pattern" : "\\d+"
         },
         {
             "name": "snapshot_year",
@@ -28,7 +30,8 @@
         {
             "name": "snapshot_month",
             "type": "int",
-            "description": "month at which snapshot of workforce was taken"
+            "description": "month at which snapshot of workforce was taken",
+            "enum" : [1,2,3,4,5,6,7,8,9,10,11,12]
         }
     ],
     "partitions" : ["snapshot_year", "snapshot_month"]

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,13 @@ from setuptools import setup, find_packages
 
 setup(
     name='etl_manager',
-    version='1.0.4',
+    version='1.0.5',
     packages=find_packages(exclude=['tests*']),
     license='MIT',
     description='A python package to manage etl processes on AWS',
     long_description=open('README.md').read(),
     install_requires=[
         "boto3 >= 1.7.4",
-        "PyAthenaJDBC >= 1.3.0",
         "jsonschema >= 2.6.0"
     ],
     include_package_data=True,


### PR DESCRIPTION
- Package now uses `boto3` to make athena calls instead of `pyathenajdbc`.
- Package no longer requires `pyathenajdbc` and therefore does not require Java install.
- Should make docker builds which need to use `refresh_paritions` or `refresh_all_table_partitions` less complex.

