### PR TITLE
Allow table path/location to be capitalised

### DIFF
--- a/etl_manager/meta.py
+++ b/etl_manager/meta.py
@@ -179,7 +179,7 @@ class TableMeta:
 
     @location.setter
     def location(self, location):
-        _validate_string(location, allowed_chars="_/-")
+        _validate_string(location, allowed_chars="_/-", allow_upper=True)
         if location and location != "":
             if location[0] == "/":
                 raise ValueError("location should not start with a slash")

--- a/etl_manager/utils.py
+++ b/etl_manager/utils.py
@@ -79,9 +79,12 @@ def _remove_final_slash(string):
 
 
 # Used by both classes (Should move into another module)
-def _validate_string(s, allowed_chars="_"):
-    if s != s.lower():
-        raise ValueError("string provided must be lowercase")
+def _validate_string(s, allowed_chars="_", allow_upper=False):
+    if allow_upper:
+        pass
+    else:
+        if s != s.lower():
+            raise ValueError("string provided must be lowercase")
 
     invalid_chars = string.punctuation
 

--- a/etl_manager/utils.py
+++ b/etl_manager/utils.py
@@ -80,11 +80,8 @@ def _remove_final_slash(string):
 
 # Used by both classes (Should move into another module)
 def _validate_string(s, allowed_chars="_", allow_upper=False):
-    if allow_upper:
-        pass
-    else:
-        if s != s.lower():
-            raise ValueError("string provided must be lowercase")
+    if s != s.lower() and not allow_upper:
+        raise ValueError("string provided must be lowercase")
 
     invalid_chars = string.punctuation
 


### PR DESCRIPTION
Table names arriving in S3 via DMS have their names in CAPITALS.
The S3 path/locaiton that Glue uses to find the table then contains upper case characters.
etl_manager doesn't allow the use of upper case characters in  table names.

This PR adds the option to allow upper case table names in the S3 path/location used by the location setter in the TableMeta class.