### PR TITLE
Allow equals in location

### DIFF
--- a/etl_manager/meta.py
+++ b/etl_manager/meta.py
@@ -196,7 +196,7 @@ class TableMeta:
 
     @location.setter
     def location(self, location):
-        _validate_string(location, allowed_chars="_/-", allow_upper=True)
+        _validate_string(location, allowed_chars="_/-=", allow_upper=True)
         if location and location != "":
             if location[0] == "/":
                 raise ValueError("location should not start with a slash")


### PR DESCRIPTION
Since hive allows = in strings it seems like we should allow it in location 