### PR TITLE
Add binary type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v7.4.0
+
+### Change
+- Add support for `binary` type
+
+## v7.3.0
+
+### Change
+- Set the default AWS Glue version to 2.0
+
 ## v7.2.0
 
 ### Change

--- a/etl_manager/meta.py
+++ b/etl_manager/meta.py
@@ -57,7 +57,7 @@ _agnostic_to_glue_spark_dict = json.load(
 )
 
 _web_link_to_table_json_schema = (
-    "https://moj-analytical-services.github.io/metadata_schema/table/v1.3.0.json"
+    "https://moj-analytical-services.github.io/metadata_schema/table/v1.4.0.json"
 )
 
 try:

--- a/etl_manager/specs/glue_spark_dict.json
+++ b/etl_manager/specs/glue_spark_dict.json
@@ -31,6 +31,10 @@
       "glue":"timestamp",
       "spark":"TimestampType"
     },
+    "binary": {
+      "glue":"binary",
+      "spark":"BinaryType"
+    },
     "boolean":{
       "glue":"boolean",
       "spark":"BooleanType"

--- a/etl_manager/specs/table_schema.json
+++ b/etl_manager/specs/table_schema.json
@@ -41,6 +41,7 @@
               "decimal",
               "date",
               "datetime",
+              "binary",
               "boolean",
               "struct",
               "array"

--- a/etl_manager/utils.py
+++ b/etl_manager/utils.py
@@ -158,7 +158,7 @@ def _unnest_github_zipfile_and_return_new_zip_path(zip_path):
 # Note the ?R recursive.  We only allow 'character' (the agnostic type), in a non-complex type, but must allow string within complex types.
 # User will still get an error for string as non-complex type from the schema.
 COL_TYPE_REGEX = regex.compile(
-    r"(character|int|long|float|double|date|datetime|boolean|decimal\(\d+,\d+\)|struct<(([a-zA-Z_]+):((?R)(,?)))+>|array<(?R)>)"
+    r"(character|int|long|float|double|date|datetime|boolean|binary|decimal\(\d+,\d+\)|struct<(([a-zA-Z_]+):((?R)(,?)))+>|array<(?R)>)"
 )
 
 

--- a/example/meta_data/db1/employees.json
+++ b/example/meta_data/db1/employees.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://moj-analytical-services.github.io/metadata_schema/table/v1.3.0.json",
+    "$schema": "https://moj-analytical-services.github.io/metadata_schema/table/v1.4.0.json",
     "name": "employees",
     "description": "table containing employee information",
     "data_format": "parquet",

--- a/example/meta_data/db1/pay.json
+++ b/example/meta_data/db1/pay.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://moj-analytical-services.github.io/metadata_schema/table/v1.3.0.json",
+    "$schema": "https://moj-analytical-services.github.io/metadata_schema/table/v1.4.0.json",
     "name": "pay",
     "description": "Check glue specific works",
     "data_format": "csv",

--- a/example/meta_data/db1/teams.json
+++ b/example/meta_data/db1/teams.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://moj-analytical-services.github.io/metadata_schema/table/v1.3.0.json",
+    "$schema": "https://moj-analytical-services.github.io/metadata_schema/table/v1.4.0.json",
     "name": "teams",
     "description": "month snapshot of which employee with working in what team",
     "data_format": "parquet",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "etl_manager"
-version = "7.3.0"
+version = "7.4.0"
 description = "A python package to manage etl processes on AWS"
 license = "MIT"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]

--- a/tests/data/data_types/test_table.json
+++ b/tests/data/data_types/test_table.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://moj-analytical-services.github.io/metadata_schema/table/v1.3.0.json",
+    "$schema": "https://moj-analytical-services.github.io/metadata_schema/table/v1.4.0.json",
     "name": "test_table",
     "description": "table containing columns with each of the data types for testing database creation",
     "data_format": "json",

--- a/tests/test_column_types.py
+++ b/tests/test_column_types.py
@@ -59,6 +59,7 @@ class ColumnTypesTest(BotoTester):
             ("decimal(38,0)", True),
             ("date", True),
             ("datetime", True),
+            ("binary", True),
             ("boolean", True),
             ("struct", False),
             ("array", False),


### PR DESCRIPTION
This PR will add support for a `binary` data type.

Requires https://github.com/moj-analytical-services/gluejobutils/pull/22 and https://github.com/moj-analytical-services/metadata_schema/pull/8 to be merged and released for tests to pass.