### PR TITLE
Added additional pip property to GlueJob

### DIFF
--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -536,7 +536,7 @@ class GlueJob:
 
         if self.pip_requirements is not None:
             pip_req = self._get_pip_requirements()
-            job_definition["DefaultArguments"]["----additional-python-modules"] = pip_req
+            job_definition["DefaultArguments"]["--additional-python-modules"] = pip_req
 
         if len(self.resources) > 0:
             extra_files = ",".join(

--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import tempfile
 import time
-from typing import Optional
+from typing import Optional, Union
 import zipfile
 from urllib.request import urlretrieve
 
@@ -133,6 +133,7 @@ class GlueJob:
 
         self.glue_version = "2.0"
         self.python_version = "3"
+        self.pip_requirements = None
 
     @property
     def timeout(self):
@@ -199,6 +200,7 @@ class GlueJob:
                 "--debug",
                 "--mode",
                 "--metadata_base_path",
+                "--additional-python-modules"
             ]
             for k in job_arguments.keys():
                 if k[:2] != "--" or k in special_aws_params:
@@ -274,6 +276,41 @@ class GlueJob:
             )
 
         self._python_version = v
+
+    @property
+    def pip_requirements(self):
+        return self._pip_requirements
+
+    @pip_requirements.setter
+    def pip_requirements(self, requirements: Union[str, None]):
+        glue_version = self.glue_version
+        if glue_version not in ["3.0", "2.0"]:
+            raise ValueError(
+                f"pip_requirements cannot be set for Glue {glue_version}"
+            )
+        if requirements is not None:
+            if not isinstance(requirements, str):
+                raise TypeError(
+                    f"pip_requirements must be a str (given {type(requirements)}"
+                )
+            try:
+                _, ext = os.path.splitext(requirements)
+            except Exception:
+                raise ValueError("requirements should be a valid filepath")
+            if ext != ".txt":
+                raise ValueError("requirements should be a filepath to a txt file")
+
+        self._pip_requirements = requirements
+
+    def _get_pip_requirements(self):
+        req_txt = self.pip_requirements
+        if req_txt is not None:
+            with open(req_txt, 'r') as f:
+                req = f.readlines()
+
+            req_str = ",".join(req).replace("\n", '')
+
+            return req_str
 
     def _check_nondup_resources(self, resources_list):
         file_list = [os.path.basename(r) for r in resources_list]
@@ -496,6 +533,10 @@ class GlueJob:
             "Tags": self.tags,
             "Timeout": self.timeout,
         }
+
+        if self.pip_requirements is not None:
+            pip_req = self._get_pip_requirements()
+            job_definition["DefaultArguments"]["----additional-python-modules"] = pip_req
 
         if len(self.resources) > 0:
             extra_files = ",".join(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "etl_manager"
-version = "7.5.1"
+version = "7.5.2"
 description = "A python package to manage etl processes on AWS"
 license = "MIT"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -110,6 +110,7 @@ class GlueTest(BotoTester):
         self.assertEqual(g.allocated_capacity, 2)
         self.assertEqual(g.glue_version, "2.0")
         self.assertEqual(g.python_version, "3")
+        self.assertEqual(g.pip_requirements, None)
 
         jobdef = g._job_definition()
         self.assertTrue("j2.jar" in jobdef["DefaultArguments"]["--extra-jars"])
@@ -260,6 +261,23 @@ class GlueTest(BotoTester):
 
         with self.assertRaises(ValueError):
             g.python_version = "1.1"
+
+    def test_pip_requirements(self):
+        g = GlueJob(
+            "example/glue_jobs/simple_etl_job/",
+            bucket="alpha-everyone",
+            job_role="alpha_user_isichei",
+        )
+
+        for glue_version in ["1.0", "0.9"]:
+            g.glue_version = glue_version
+            self.assertEqual(g.pip_requirements, None)
+
+        for glue_version in ["2.0", "3.0"]:
+            g.glue_version = glue_version
+            for fp in ["gibberish", "requirements"]:
+                with self.assertRaises(ValueError) as context:
+                    g.pip_requirements = fp
 
 
 class TableTest(BotoTester):


### PR DESCRIPTION
Added `pip_requirements` as an additional property to `GlueJob`. This will pass pip requirements specified in a txt file to the job definition as outlined [here](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-libraries.html#addl-python-modules-support). This option is not enable by default, and has to be explicitly set after initialising the `GlueJob` object.

Basic tests have been added to ensure this change doesn't break the normal way of using `GlueJob`.