### PR TITLE
meta.py - changes to to_dict & write_to_json functions

### DIFF
--- a/etl_manager/meta.py
+++ b/etl_manager/meta.py
@@ -480,7 +480,7 @@ class TableMeta:
 
         return glue_table_definition
 
-    def to_dict(self):
+    def to_dict(self, always_key=False):
         meta = {
             "$schema": _web_link_to_table_json_schema,
             "name": self.name,
@@ -492,17 +492,21 @@ class TableMeta:
 
         if bool(self.partitions):
             meta["partitions"] = self.partitions
+        elif always_key:
+            meta["partitions"] = None
 
         if bool(self.primary_key):
             meta["primary_key"] = self.primary_key
+        elif always_key:
+            meta["primary_key"] = None
 
         if bool(self.glue_specific):
             meta["glue_specific"] = self.glue_specific
 
         return meta
 
-    def write_to_json(self, file_path):
-        write_json(self.to_dict(), file_path)
+    def write_to_json(self, file_path, always_key=False):
+        write_json(self.to_dict(always_key), file_path)
 
     def generate_markdown_doc(self, filepath):
         """


### PR DESCRIPTION
The dictionary created by the to_dict function will not contain the partitions key and primary key if the value is an empty object.
Added the argument 'always_key' to the to_dict function and write_to_json functions.
Default value of argument is set to False.
If always_key = False, no impact on the output.
If always_key = True and value is an empty object, the partitions key and primary key will be in the dictionary with a value of null. 
This functionality is required to extract metadata in the expected format in the analytical-platform-data-engineering repo. 