### PR TITLE
Add workerType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v8.0.0
+
+### Change
+
+- Add support for WorkerType and NumberOfWorkers (removing AllocatedCapacity - hence breaking change)
 
 ## v7.6.0
 

--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -129,9 +129,8 @@ class GlueJob:
         self._job_run_id = None
         self.max_retries = 0
         self.max_concurrent_runs = 1
-        self.allocated_capacity = 2
+        self.number_of_workers = 2
         self.worker_type = "G.1X"
-
         self.glue_version = "2.0"
         self.python_version = "3"
         self.pip_requirements = None
@@ -139,15 +138,14 @@ class GlueJob:
     @property
     def timeout(self):
         if self.timeout_override_minutes is None:
-            # 1 DPU for "G.1X", etc.
-            dpu_count = float(self.worker_type[2] + '.' + self.worker_type[3:-1])
-            
+            # "G.2X" -> 2.0
+            dpu_per_worker = float(self.worker_type[2]+'.'+self.worker_type[3:-1])
             # 60 because timeout is in munites, whereas glue worker cost is in hours
             return int(
                 60
                 * (
                     self.MAXIMUM_COST_TIMEOUT
-                    / (self.GLUE_WORKER_HOURLY_COST * self.allocated_capacity * dpu_count)
+                    / (self.GLUE_WORKER_HOURLY_COST * dpu_per_worker * self.number_of_workers)
                 )
             )
         else:
@@ -547,8 +545,8 @@ class GlueJob:
                 "--job-bookmark-option": "job-bookmark-disable",
             },
             "MaxRetries": self.max_retries,
-            "AllocatedCapacity": self.allocated_capacity,
             "WorkerType": self.worker_type,
+            "NumberOfWorkers": self.number_of_workers,
             "GlueVersion": self.glue_version,
             "Tags": self.tags,
             "Timeout": self.timeout,

--- a/etl_manager/etl.py
+++ b/etl_manager/etl.py
@@ -130,7 +130,7 @@ class GlueJob:
         self.max_retries = 0
         self.max_concurrent_runs = 1
         self.allocated_capacity = 2
-        self.worker_type = "G1.X"
+        self.worker_type = "G.1X"
 
         self.glue_version = "2.0"
         self.python_version = "3"
@@ -276,7 +276,7 @@ class GlueJob:
             raise TypeError(f"worker_type must be of type str (given {type(t)})")
         if t not in valid_worker_types:
             raise ValueError(
-                f"worker_type must be one of {valid_glue_versions} (give {t})"
+                f"worker_type must be one of {valid_worker_types} (give {t})"
             )
         self._worker_type = t
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "etl_manager"
-version = "7.6.1"
+version = "8.0.0"
 description = "A python package to manage etl processes on AWS"
 license = "MIT"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "etl_manager"
-version = "7.6.0"
+version = "7.6.1"
 description = "A python package to manage etl processes on AWS"
 license = "MIT"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -107,7 +107,8 @@ class GlueTest(BotoTester):
         self.assertEqual(g.github_py_resources, [])
         self.assertEqual(g.max_retries, 0)
         self.assertEqual(g.max_concurrent_runs, 1)
-        self.assertEqual(g.allocated_capacity, 2)
+        self.assertEqual(g.worker_type, "G.1X")
+        self.assertEqual(g.number_of_workers, 2)
         self.assertEqual(g.glue_version, "2.0")
         self.assertEqual(g.python_version, "3")
         self.assertEqual(g.pip_requirements, None)
@@ -175,11 +176,13 @@ class GlueTest(BotoTester):
 
         self.assertEqual(g._job_definition()["Timeout"], 1363)
 
-        g.allocated_capacity = 10
+        g.number_of_workers = 5
+        g.worker_type = "G.2X"
 
         self.assertEqual(g._job_definition()["Timeout"], 272)
 
-        g.allocated_capacity = 40
+        g.number_of_workers = 40
+        g.worker_type = "G.1X"
 
         self.assertEqual(g._job_definition()["Timeout"], 68)
 
@@ -191,7 +194,7 @@ class GlueTest(BotoTester):
             timeout_override_minutes=2880,
         )
 
-        g.allocated_capacity = 40
+        g.number_of_workers = 40
 
         self.assertEqual(g._job_definition()["Timeout"], 2880)
 


### PR DESCRIPTION
https://docs.aws.amazon.com/glue/latest/webapi/API_CreateJob.html#Glue-CreateJob-request-WorkerType

Enabling different worker types to make more cost-effective use of resources (i.e. doubling DPUs per worker rather than doubling the number of workers).

https://aws.amazon.com/blogs/big-data/scale-your-aws-glue-for-apache-spark-jobs-with-new-larger-worker-types-g-4x-and-g-8x/

`AllocatedCapacity` is now deprecated, so is replaced by `NumberOfWorkers` and `WorkerType` (i.e. `AllocatedCapacity` = 10 DPUs -> 5 x "G.2X" / 10 x "G.1X" workers )